### PR TITLE
fix compile issue for Arduino Nano 33 BLE, using PIN_WIRE_SDA and PIN_WIRE_SCL

### DIFF
--- a/DFRobot_MLX90614.cpp
+++ b/DFRobot_MLX90614.cpp
@@ -154,19 +154,19 @@ void DFRobot_MLX90614_I2C::enterSleepMode(bool mode)
     #endif
 
     // wake up command, refer to the chip datasheet
-    pinMode(SDA, OUTPUT);
-    pinMode(SCL, OUTPUT);
-    digitalWrite(SCL, LOW);
-    digitalWrite(SDA, HIGH);
+    pinMode(PIN_WIRE_SDA, OUTPUT);
+    pinMode(PIN_WIRE_SCL, OUTPUT);
+    digitalWrite(PIN_WIRE_SCL, LOW);
+    digitalWrite(PIN_WIRE_SDA, HIGH);
     delay(50);
-    digitalWrite(SCL, HIGH);
-    digitalWrite(SDA, LOW);
+    digitalWrite(PIN_WIRE_SCL, HIGH);
+    digitalWrite(PIN_WIRE_SDA, LOW);
     delay(50);
 
     _pWire->begin();   // Wire.h（I2C）library function initialize wire library
 
     #ifdef ESP8266
-      digitalWrite(SCL, LOW);
+      digitalWrite(PIN_WIRE_SCL, LOW);
     #endif
 
     _pWire->beginTransmission(_deviceAddr);


### PR DESCRIPTION
fix compile issue for Arduino Nano 33 BLE, using PIN_WIRE_SDA and PIN_WIRE_SCL